### PR TITLE
docs: add deeplink for cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Documentation is cloned into a temporary directory, and Markdown files are index
 
 ### Cursor
 
+### Quick Install with Cursor Deeplink
+
+For Cursor users, you can install the MCP server with a single click using the deeplink below:
+
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=pipe-cd.docs-mcp-server&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoibnB4IEBwaXBlLWNkL2RvY3MtbWNwLXNlcnZlckBsYXRlc3QifQ%3D%3D)
+
+This will automatically configure the MCP server in your Cursor settings. After clicking the link, Cursor will prompt you to install the server.
+
+### Install Using npx
+
 Add the following config to your mcp.json.
 
 ```json


### PR DESCRIPTION
- Add deeplink(https://docs.cursor.com/deeplinks)