### PR TITLE
fix: MCP stdio transport and add tool descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Documentation is cloned into a temporary directory, and Markdown files are index
 
 For Cursor users, you can install the MCP server with a single click using the deeplink below:
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=pipe-cd.docs-mcp-server&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoibnB4IEBwaXBlLWNkL2RvY3MtbWNwLXNlcnZlckBsYXRlc3QifQ%3D%3D)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=pipe-cd.docs-mcp-server&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoibnB4IEBwaXBlLWNkL2RvY3MtbWNwLXNlcnZlckBsYXRlc3QifQ%3D%3D)
 
 This will automatically configure the MCP server in your Cursor settings. After clicking the link, Cursor will prompt you to install the server.
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -25,7 +25,7 @@ export async function loadDocsFromGitHub(): Promise<DocFile[]> {
 	}
 
 	try {
-		console.info(`Start cloning repo ${REPO} to ${targetDir}`);
+		console.error(`Start cloning repo ${REPO} to ${targetDir}`);
 		await git.clone(REPO, targetDir, [
 			"--depth",
 			"1",
@@ -36,7 +36,7 @@ export async function loadDocsFromGitHub(): Promise<DocFile[]> {
 		]);
 		await git.cwd(targetDir);
 		await git.raw(["sparse-checkout", "set", DOCS_PATH]);
-		console.info(`Successfully cloned repo ${REPO} to ${targetDir}`);
+		console.error(`Successfully cloned repo ${REPO} to ${targetDir}`);
 	} catch (error) {
 		console.error(`Error while cloning repo ${REPO} to ${targetDir}: ${error}`);
 		throw error;

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ async function main() {
 
 	server.tool(
 		"search_docs",
+		"Executes a full-text search on PipeCD docs. Provide space-separated keywords (AND search), a starting offset, and an optional result limit.",
 		{
 			query: z.string(),
 			offset: z.number(),
@@ -45,12 +46,19 @@ async function main() {
 		},
 	);
 	// NOTE: read_docs might not be called because search_docs contains contents.
-	server.tool("read_docs", { path: z.string() }, async ({ path }) => {
-		const doc = docsIndexes.find((doc) => doc.path === path);
-		return {
-			content: [{ type: "text", text: doc?.content ?? "document not found" }],
-		};
-	});
+	server.tool(
+		"read_docs",
+		'Returns the full content of a specified PipeCD doc page. Provide the relative path of the document (after "docs/content/en/").',
+		{ path: z.string() },
+		async ({ path }) => {
+			const doc = docsIndexes.find((doc) => doc.path === path);
+			return {
+				content: [
+					{ type: "text", text: doc?.content ?? "document not found" },
+				],
+			};
+		},
+	);
 
 	// Start receiving messages on stdin and sending messages on stdout
 	const transport = new StdioServerTransport();

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ async function main() {
 
 	server.tool(
 		"search_docs",
-		"Executes a full-text search on PipeCD docs. Provide space-separated keywords (AND search), a starting offset, and an optional result limit.",
+		"Full-text search over PipeCD docs. Query is space-separated keywords (AND search).",
 		{
 			query: z.string(),
 			offset: z.number(),


### PR DESCRIPTION
This pull request improves the developer experience and API usability for the PipeCD docs tools by adding helpful descriptions to the API methods and making minor logging adjustments. The key changes are grouped below:

API usability improvements:

* Added descriptive text for the `search_docs` tool, clarifying that it performs a full-text AND search over PipeCD docs using space-separated keywords.
* Enhanced the `read_docs` tool by providing a clear description of its purpose and usage, specifying that it returns the full content of a specified doc page and how to provide the path.

Logging changes:

* Changed log messages from `console.info` to `console.error` in `src/loader.ts` for both the start and successful completion of the repository cloning process. [[1]](diffhunk://#diff-0a1342822ff2e711a79fd7036fdc352146751bd42d7d5845a2938f903723f74bL28-R28) [[2]](diffhunk://#diff-0a1342822ff2e711a79fd7036fdc352146751bd42d7d5845a2938f903723f74bL39-R39)

After modified MCP Server working fine locally and we need to create the new release

<img width="620" height="280" alt="image" src="https://github.com/user-attachments/assets/83e41909-b5c4-43ee-aa8d-651232906093" />
